### PR TITLE
[MRG?] Access matrices through iterators where possible: the case of the major diagonal.

### DIFF
--- a/src/algebra/ops.rs
+++ b/src/algebra/ops.rs
@@ -1,3 +1,4 @@
+#![feature(associated_type_defaults)]
 #![doc="Defines some operators.
 "]
 

--- a/src/linalg/singularity.rs
+++ b/src/linalg/singularity.rs
@@ -53,14 +53,7 @@ pub fn is_singular_diagonal<T:CommutativeMonoidAddPartial+CommutativeMonoidMulPa
 
 /// Checks if any entry on the main diagonal is zero
 pub fn has_zero_on_diagonal<T:CommutativeMonoidAddPartial>(m : &Matrix<T>) -> bool {
-    let n = cmp::min(m.num_rows(), m.num_cols());
-    let z : T = Zero::zero();
-    for i in 0..n{
-        if unsafe { m.get_unchecked(i, i) } == z {
-            return true;
-        }
-    }
-    false
+    m.diagonal_iter().any(|x| x == T::zero())
 }
 
 #[cfg(test)]

--- a/src/matrix/iter.rs
+++ b/src/matrix/iter.rs
@@ -112,4 +112,31 @@ impl <T:MagmaBase> Iterator for CellIterator<T> {
     }
 }
 
+/// An iterator over the major diagonal of a matrix.
+pub struct DiagIterator<T:MagmaBase>{
+    min_dim_size : usize,
+    stride: usize,
+    pos  : usize, 
+    ptr : *const T
+}
+
+impl <T:MagmaBase> DiagIterator<T> {
+    /// Creates a new iterator object
+    pub fn new(min_dim_size : usize, stride : usize, ptr : *const T)-> DiagIterator<T>{
+        DiagIterator{min_dim_size : min_dim_size, stride : stride, pos : 0, ptr : ptr}
+    }
+}
+
+impl <T:MagmaBase> Iterator for DiagIterator<T> {
+    type Item = T;
+    fn next(&mut self) -> Option<T> {
+        if self.min_dim_size == self.pos{
+            // No more data
+            return None;
+        }
+        let offset = self.pos * (self.stride + 1);
+        self.pos += 1;
+        Some(unsafe{*self.ptr.offset(offset as isize).clone()})
+    }
+}
 

--- a/src/matrix/iter.rs
+++ b/src/matrix/iter.rs
@@ -115,15 +115,16 @@ impl <T:MagmaBase> Iterator for CellIterator<T> {
 /// An iterator over the major diagonal of a matrix.
 pub struct DiagIterator<T:MagmaBase>{
     min_dim_size : usize,
-    stride: usize,
-    pos  : usize, 
+    step_size: usize,
+    offset : usize,
+    pos : usize, 
     ptr : *const T
 }
 
 impl <T:MagmaBase> DiagIterator<T> {
     /// Creates a new iterator object
     pub fn new(min_dim_size : usize, stride : usize, ptr : *const T)-> DiagIterator<T>{
-        DiagIterator{min_dim_size : min_dim_size, stride : stride, pos : 0, ptr : ptr}
+        DiagIterator{min_dim_size : min_dim_size, step_size : stride + 1, offset : 0, pos : 0, ptr : ptr}
     }
 }
 
@@ -134,9 +135,10 @@ impl <T:MagmaBase> Iterator for DiagIterator<T> {
             // No more data
             return None;
         }
-        let offset = self.pos * (self.stride + 1);
+        let res = Some(unsafe{*self.ptr.offset(self.offset as isize).clone()});
+        self.offset += self.step_size;
         self.pos += 1;
-        Some(unsafe{*self.ptr.offset(offset as isize).clone()})
+        res
     }
 }
 

--- a/src/matrix/matrix.rs
+++ b/src/matrix/matrix.rs
@@ -530,11 +530,6 @@ impl<T:CommutativeMonoidAddPartial+CommutativeMonoidMulPartial> NumberMatrix<T> 
     }
 }
 
-/// Provide the main diagonal elements
-fn diagonal_iter<T: CommutativeMonoidAddPartial+CommutativeMonoidMulPartial>(a: &Matrix<T>) -> DiagIterator<T>{
-    DiagIterator::new(a.smaller_dim(),a.stride(), a.ptr)
-}
-
 
 /// Introspection support
 impl<T> Introspection for Matrix<T> {
@@ -647,6 +642,12 @@ impl<T:CommutativeMonoidAddPartial+One> Matrix<T> {
         iter
     }
 
+    /// Provide the main diagonal elements
+    fn diagonal_iter(&self) -> DiagIterator<T>{
+        DiagIterator::new(self.smaller_dim(),self.stride(), self.ptr)
+    }
+
+
 
     // Repeats this matrix in both horizontal and vertical directions 
     pub fn repeat_matrix(&self, num_rows : usize, num_cols : usize) -> Matrix<T> {
@@ -678,12 +679,10 @@ impl<T:CommutativeMonoidAddPartial+One> Matrix<T> {
     pub fn diagonal_vector(&self) -> Matrix<T> {
         let m  = self.smaller_dim();
         let result : Matrix<T> = Matrix::new(m, 1);
-        let src = self.ptr;
         let dst = result.ptr;
-        for i in 0..m{
-            let offset = self.cell_to_offset(i, i);
+        for (i, e) in (0..m).zip(self.diagonal_iter()){
             unsafe{
-                *dst.offset(i as isize) = *src.offset(offset);
+                *dst.offset(i as isize) = e;
             } 
         }
         result        
@@ -1984,6 +1983,7 @@ mod test {
     fn test_diagonal(){
         let m  : MatrixI64 = Matrix::from_iter_cw(4, 5, (10..30));
         let v = m.diagonal_vector();
+        println!("m: {} v: {}", m, v);
         assert!(v.is_vector());
         assert_eq!(v.num_cells(), 4);
         let v2 : MatrixI64 = Matrix::from_slice_cw(4, 1, vec![10, 15, 20, 25].as_slice());

--- a/src/matrix/matrix.rs
+++ b/src/matrix/matrix.rs
@@ -530,6 +530,12 @@ impl<T:CommutativeMonoidAddPartial+CommutativeMonoidMulPartial> NumberMatrix<T> 
     }
 }
 
+/// Provide the main diagonal elements
+fn diagonal_iter<T: CommutativeMonoidAddPartial+CommutativeMonoidMulPartial>(a: &Matrix<T>) -> DiagIterator<T>{
+    DiagIterator::new(a.smaller_dim(),a.stride(), a.ptr)
+}
+
+
 /// Introspection support
 impl<T> Introspection for Matrix<T> {
     /// This is a standard matrix object

--- a/src/matrix/matrix.rs
+++ b/src/matrix/matrix.rs
@@ -605,10 +605,11 @@ impl<T:MagmaBase> Matrix<T> {
 }
 
 
-/// Functions to construct new matrices out of a matrix and other conversions
-impl<T:CommutativeMonoidAddPartial+One> Matrix<T> {
 
+use std::fmt::Debug;
 
+/// Functions to access matrix elements safely and without bounds checking.
+impl<T: Debug + Clone + Copy + PartialEq> Matrix<T> {
 
     /// Returns an iterator over a specific row of matrix
     pub fn row_iter(&self, r : isize) -> RowIterator<T>{
@@ -639,11 +640,13 @@ impl<T:CommutativeMonoidAddPartial+One> Matrix<T> {
     }
 
     /// Provide the main diagonal elements
-    fn diagonal_iter(&self) -> DiagIterator<T>{
+    pub fn diagonal_iter(&self) -> DiagIterator<T>{
         DiagIterator::new(self.smaller_dim(),self.stride(), self.ptr)
     }
+}
 
-
+/// Functions to construct new matrices out of a matrix and other conversions
+impl<T:CommutativeMonoidAddPartial+One> Matrix<T> {
 
     // Repeats this matrix in both horizontal and vertical directions 
     pub fn repeat_matrix(&self, num_rows : usize, num_cols : usize) -> Matrix<T> {

--- a/src/matrix/matrix.rs
+++ b/src/matrix/matrix.rs
@@ -518,13 +518,9 @@ impl<T:CommutativeMonoidAddPartial+CommutativeMonoidMulPartial> NumberMatrix<T> 
 
     /// Returns the trace of the matrix
     fn trace(&self) -> T{
-        let step = (self.stride() as isize) + 1;
         let mut result: T = Zero::zero();
-        let mut offset = 0;
-        let ptr = self.as_ptr();
-        for i in 0..self.smaller_dim(){
-            result = result + unsafe {*ptr.offset(offset)};
-            offset += step;
+        for e in self.diagonal_iter(){
+            result = result + e;
         }
         result
     }

--- a/src/matrix/matrix.rs
+++ b/src/matrix/matrix.rs
@@ -518,16 +518,13 @@ impl<T:CommutativeMonoidAddPartial+CommutativeMonoidMulPartial> NumberMatrix<T> 
 
     /// Returns the trace of the matrix
     fn trace(&self) -> T{
-        if self.is_empty() {
-            return Zero::zero()
-        }
-        let mut result = self.get(0, 0);
-        let stride = self.stride() as isize;
-        let mut offset = stride;
+        let step = (self.stride() as isize) + 1;
+        let mut result: T = Zero::zero();
+        let mut offset = 0;
         let ptr = self.as_ptr();
-        for i in 1..self.smaller_dim(){
-            result = result + unsafe{*ptr.offset(offset + i as isize)};
-            offset += stride;
+        for i in 0..self.smaller_dim(){
+            result = result + unsafe {*ptr.offset(offset)};
+            offset += step;
         }
         result
     }
@@ -2008,6 +2005,7 @@ mod test {
         let m = matrix_cw_f64(3, 3, &[1., 0., 0., 
             4., 5., 0.,
             6., 2., 3.]);
+        println!("{}", m.trace());
         assert_eq!(m.trace(), 9.);
     }
 


### PR DESCRIPTION
Not ready for merge. Started from changing implementation of trace to use uniform access to the diagonal elements. Current plan is:
- Separate the access loop into its own function. 
- Put the function interface into a trait function. The "Shape" trait seems like the right place.
- Move trace functionality into a trait... maybe NumberMatrix?

If this sounds ok, I'll do those, then generalize to other functionality.