### PR TITLE
Block multiplication of matrices.

### DIFF
--- a/src/matrix/transpose/matrix_transpose.rs
+++ b/src/matrix/transpose/matrix_transpose.rs
@@ -178,7 +178,7 @@ impl <T:CommutativeMonoidAddPartial+CommutativeMonoidMulPartial> Frame<T> for Ma
     rhs: &Matrix<T>)->SRResult<Matrix<T>>{
     use std::{cmp, slice};
     use std::ops::Add;
-    const BLOCK_SIZE:usize = 8;
+    const BLOCK_SIZE:usize = 16;
     // Validate dimensions match for multiplication
     if lhs.num_cols() != rhs.num_rows(){
         return Err(SRError::DimensionsMismatch);

--- a/src/matrix/transpose/matrix_transpose.rs
+++ b/src/matrix/transpose/matrix_transpose.rs
@@ -502,23 +502,43 @@ mod bench {
                 });
     }
 
-    #[bench]
-    fn bench_multiply_simple(b: &mut Bencher){
-        let m = hadamard(MULTIPLY_MATRIX_SIZE).unwrap();
-        b.iter(|| {
-                    // Matrix multiplication
-                    multiply_simple(&m, &m).is_ok();
-                });
+    macro_rules! make_multiply_bench {
+        ($simple_name:ident, $block_name:ident, $matrix_size:expr) => (
+            #[bench]
+            fn $simple_name(b: &mut Bencher){
+                let m = hadamard($matrix_size).unwrap();
+                b.iter(|| {
+                            // Matrix multiplication
+                            multiply_simple(&m, &m).is_ok();
+                        });
+            }
+            #[bench]
+            fn $block_name(b: &mut Bencher){
+                let m = hadamard($matrix_size).unwrap();
+                b.iter(|| {
+                            // Matrix multiplication
+                            multiply_block(&m, &m).is_ok();
+                        });
+            }
+        );
+        // ($name_end:ident, $matrix_size:expr) => (
+        //     make_multiply_bench(concat_idents!(bench_multiply_simple, $name_end),
+        //         concat_idents!(bench_multiply_block, $name_end),
+        //         $matrix_size);
+        //     )
     }
-
-    #[bench]
-    fn bench_multiply_block(b: &mut Bencher){
-        let m = hadamard(MULTIPLY_MATRIX_SIZE).unwrap();
-        b.iter(|| {
-                    // Matrix multiplication
-                    multiply_block(&m, &m).is_ok();
-                });
-    }
+    //the position of the numbers and the leading zeroes sort the benches intuitively
+    make_multiply_bench!(bench_multiply_0001_simple, bench_multiply_0001_block, 1);
+    make_multiply_bench!(bench_multiply_0002_simple, bench_multiply_0002_block, 2);
+    make_multiply_bench!(bench_multiply_0004_simple, bench_multiply_0004_block, 4);
+    make_multiply_bench!(bench_multiply_0008_simple, bench_multiply_0008_block, 8);
+    make_multiply_bench!(bench_multiply_0016_simple, bench_multiply_0016_block, 16);
+    make_multiply_bench!(bench_multiply_0032_simple, bench_multiply_0032_block, 32);
+    make_multiply_bench!(bench_multiply_0064_simple, bench_multiply_0064_block, 64);
+    make_multiply_bench!(bench_multiply_0128_simple, bench_multiply_0128_block, 128);
+    make_multiply_bench!(bench_multiply_0256_simple, bench_multiply_0256_block, 256);
+    make_multiply_bench!(bench_multiply_0512_simple, bench_multiply_0512_block, 512);
+    make_multiply_bench!(bench_multiply_1024_simple, bench_multiply_1024_block, 1024);
 
     #[bench]
     fn bench_multiply_transpose_simple(b: &mut Bencher){


### PR DESCRIPTION
I've wrote a function multiplying matrices by blocks. It should to be faster on larger matrices due to cache related issues of the simple multiplication function. It doesn't change the memory layout of the matrix.

I've tested the performance of both the simple (previous) and block multiplication of square matrices. For block size of 16 (it performed best on my computer) the block multiplication is outperforming the simple multiplication when matrix size is 32x32 and when the matrix size is 256x256 it's twice as fast as simple multiplication. I've copied the bench output at the end of this post.

PS: This is my first pull request, so i doubt it's well-formed. I wasn't sure if I had to raise an issue before making a pullrequest . Also I'm not sure if the code is readable enough.


This is the bench output on my Intel i7-3740QM PC.
test matrix::transpose::matrix_transpose::bench::bench_gram_optimized
     ... bench:   3,174,322 ns/iter (+/- 169,171)
test matrix::transpose::matrix_transpose::bench::bench_gram_simple
     ... bench:   6,123,006 ns/iter (+/- 241,711)
test matrix::transpose::matrix_transpose::bench::bench_multiply_0001_block
     ... bench:         273 ns/iter (+/- 78)
test matrix::transpose::matrix_transpose::bench::bench_multiply_0001_simple
     ... bench:          32 ns/iter (+/- 2)
test matrix::transpose::matrix_transpose::bench::bench_multiply_0002_block
     ... bench:         292 ns/iter (+/- 6)
test matrix::transpose::matrix_transpose::bench::bench_multiply_0002_simple
     ... bench:          45 ns/iter (+/- 7)
test matrix::transpose::matrix_transpose::bench::bench_multiply_0004_block
     ... bench:         378 ns/iter (+/- 11)
test matrix::transpose::matrix_transpose::bench::bench_multiply_0004_simple
     ... bench:          99 ns/iter (+/- 14)
test matrix::transpose::matrix_transpose::bench::bench_multiply_0008_block
     ... bench:         793 ns/iter (+/- 160)
test matrix::transpose::matrix_transpose::bench::bench_multiply_0008_simple
     ... bench:         444 ns/iter (+/- 64)
test matrix::transpose::matrix_transpose::bench::bench_multiply_0016_block
     ... bench:       3,378 ns/iter (+/- 274)
test matrix::transpose::matrix_transpose::bench::bench_multiply_0016_simple
     ... bench:       2,602 ns/iter (+/- 174)
test matrix::transpose::matrix_transpose::bench::bench_multiply_0032_block
     ... bench:      25,345 ns/iter (+/- 1,643)
test matrix::transpose::matrix_transpose::bench::bench_multiply_0032_simple
     ... bench:      28,967 ns/iter (+/- 813)
test matrix::transpose::matrix_transpose::bench::bench_multiply_0064_block
     ... bench:     192,730 ns/iter (+/- 23,921)
test matrix::transpose::matrix_transpose::bench::bench_multiply_0064_simple
     ... bench:     242,750 ns/iter (+/- 4,406)
test matrix::transpose::matrix_transpose::bench::bench_multiply_0128_block
     ... bench:   1,559,674 ns/iter (+/- 92,525)
test matrix::transpose::matrix_transpose::bench::bench_multiply_0128_simple
     ... bench:   2,045,354 ns/iter (+/- 245,310)
test matrix::transpose::matrix_transpose::bench::bench_multiply_0256_block
     ... bench:  12,406,499 ns/iter (+/- 498,650)
test matrix::transpose::matrix_transpose::bench::bench_multiply_0256_simple
     ... bench:  27,055,370 ns/iter (+/- 753,259)
test matrix::transpose::matrix_transpose::bench::bench_multiply_0512_block
     ... bench: 101,763,380 ns/iter (+/- 10,103,632)
test matrix::transpose::matrix_transpose::bench::bench_multiply_0512_simple
     ... bench: 227,811,582 ns/iter (+/- 21,193,979)