### PR TITLE
Fix compilation on the latest nightly.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@
 extern crate log;
 extern crate rand;
 extern crate num;
+extern crate alloc;
 
 // Common modules
 pub mod error;

--- a/src/matrix/matrix.rs
+++ b/src/matrix/matrix.rs
@@ -9,13 +9,13 @@ use std::cmp;
 use std::fmt;
 use num::{Float};
 use std::iter::Iterator;
-use std::rt::heap::{allocate, deallocate};
 use std::ops::{Index};
 use std::raw::Slice;
 
 // external imports
 use num::traits::{Zero, One, Signed};
 use num::complex::{Complex32, Complex64};
+use alloc::heap::{allocate, deallocate};
 
 // local imports
 

--- a/src/matrix/triangular_matrix.rs
+++ b/src/matrix/triangular_matrix.rs
@@ -6,10 +6,10 @@
 use std::ptr;
 use std::mem;
 use std::fmt;
-use std::rt::heap::allocate;
 
 // external imports
 use num::traits::{Zero, One};
+use alloc::heap::allocate;
 // complex numbers
 use num::complex::{Complex32, Complex64};
 

--- a/src/util/memory.rs
+++ b/src/util/memory.rs
@@ -1,7 +1,9 @@
 
 // std imports
 use std::mem;
-use std::rt::heap::{deallocate};
+
+// external imports
+use alloc::heap::{deallocate};
 
 
 


### PR DESCRIPTION
For reference:

    $ rustc --version
    rustc 1.5.0-nightly (cff041170 2015-09-17)

Fixes compilation errors caused by the removal of `std::rt::heap`.

Due to [RFC 1214](https://github.com/rust-lang/rust/issues/27579) this then spits out many warnings. Initially these were simple to fix (you just need to be more explicit with your trait bounds) but in order to fix all the warnings you need to implement `Copy` for `Matrix` which you obviously can't do since it implements `Drop`. For that reason I didn't fix any of the warnings, only the errors.